### PR TITLE
Global Variables

### DIFF
--- a/components/interpreters/50/table.rb
+++ b/components/interpreters/50/table.rb
@@ -45,7 +45,7 @@ module Component
 
           tuples << [key[:value], value[:value]]
 
-          break if value[:type] == 'no value'
+          break if value[:type] == 'no value' || key[:value].instance_of?(Proc)
         end
 
         { value: Logic::Tables[:to_hash_or_array].(tuples), pop: true }
@@ -78,7 +78,7 @@ module Component
             break
           end
 
-          break if value[:type] == 'no value'
+          break if value[:type] == 'no value' || key[:value].instance_of?(Proc)
         end
 
         api.lua_settop(state[:lua], -2)

--- a/components/interpreters/51/interpreter.rb
+++ b/components/interpreters/51/interpreter.rb
@@ -31,8 +31,13 @@ module Component
         { state: state, error: Interpreter[:_error].(api, state, result, pull: true) }
       },
 
-      set_table!: ->(api, state, variable, value) {
-        Table[:set!].(api, state, variable, value)
+      set_table!: ->(api, state) {
+        result = api.lua_settable(state[:lua], -3)
+
+        api.lua_settop(state[:lua], -2)
+
+        { state: state,
+          error: Interpreter[:_error].(api, state, result, pull: false) }
       },
 
       push_value!: ->(api, state, value) {
@@ -60,7 +65,7 @@ module Component
           end
         end
 
-        { state: state }
+        { state: state, extra_pop: true }
       },
 
       call!: ->(api, state, inputs = 0, outputs = 1) {

--- a/components/interpreters/51/table.rb
+++ b/components/interpreters/51/table.rb
@@ -45,7 +45,7 @@ module Component
 
           tuples << [key[:value], value[:value]]
 
-          break if value[:type] == 'no value'
+          break if value[:type] == 'no value' || key[:value].instance_of?(Proc)
         end
 
         { value: Logic::Tables[:to_hash_or_array].(tuples), pop: true }

--- a/components/interpreters/54/interpreter.rb
+++ b/components/interpreters/54/interpreter.rb
@@ -30,8 +30,13 @@ module Component
         { state: state, error: Interpreter[:_error].(api, state, result, pull: true) }
       },
 
-      set_table!: ->(api, state, variable, value) {
-        Table[:set!].(api, state, variable, value)
+      set_table!: ->(api, state) {
+        result = api.lua_settable(state[:lua], -3)
+
+        api.lua_settop(state[:lua], -2)
+
+        { state: state,
+          error: Interpreter[:_error].(api, state, result, pull: false) }
       },
 
       push_value!: ->(api, state, value) {
@@ -56,7 +61,7 @@ module Component
           end
         end
 
-        { state: state }
+        { state: state, extra_pop: true }
       },
 
       call!: ->(api, state, inputs = 0, outputs = 1) {

--- a/config/tests.sample.yml
+++ b/config/tests.sample.yml
@@ -1,5 +1,7 @@
 # Available at https://github.com/gbaptista/sweet-moon-test
 
+fennel-dev: '/home/me/sweet-moon-test/fennel-dev.lua'
+
 luarocks:
   path:
     - /home/me/.luarocks/share/lua/5.4/?.lua

--- a/dsl/fennel.rb
+++ b/dsl/fennel.rb
@@ -11,9 +11,13 @@ module DSL
         'table.insert(package.loaders or package.searchers, fennel.searcher)'
       )
 
+      # TODO: Makes sense?
+      # debug.traceback = fennel.traceback
+
       @eval = @state.get(:fennel, :eval)
       @dofile = @state.get(:fennel, :dofile)
       @version = @state.get(:fennel, :version)
+      @mangle = @state.get(:fennel, :mangle)
 
       build_meta
     end
@@ -24,6 +28,14 @@ module DSL
 
     def load(path, outputs = 1)
       @dofile.([path], outputs)
+    end
+
+    def get(variable, key = nil)
+      super(@mangle.([variable]), key)
+    end
+
+    def set(variable, value)
+      super(@mangle.([variable]), value)
     end
 
     def build_meta

--- a/dsl/fennel.rb
+++ b/dsl/fennel.rb
@@ -17,7 +17,6 @@ module DSL
       @eval = @state.get(:fennel, :eval)
       @dofile = @state.get(:fennel, :dofile)
       @version = @state.get(:fennel, :version)
-      @mangle = @state.get(:fennel, :mangle)
 
       build_meta
     end
@@ -28,14 +27,6 @@ module DSL
 
     def load(path, outputs = 1)
       @dofile.([path], outputs)
-    end
-
-    def get(variable, key = nil)
-      super(@mangle.([variable]), key)
-    end
-
-    def set(variable, value)
-      super(@mangle.([variable]), value)
     end
 
     def build_meta

--- a/dsl/state.rb
+++ b/dsl/state.rb
@@ -34,8 +34,10 @@ module DSL
       @controller[:get!].(@api, @interpreter, state, variable, key)[:output]
     end
 
-    def set(variable, value)
-      @controller[:set!].(@api, @interpreter, state, variable, value)[:output]
+    def set(variable, key_or_value, value = nil)
+      @controller[:set!].(
+        @api, @interpreter, state, variable, key_or_value, value
+      )[:output]
     end
 
     def destroy

--- a/logic/interpreters/interpreter_50.rb
+++ b/logic/interpreters/interpreter_50.rb
@@ -6,6 +6,7 @@ module Logic
       LUA_REGISTRYINDEX: -10_000,
       LUA_GLOBALSINDEX: -10_001,
 
+      # lua_isinteger lua_pushinteger lua_tointeger
       requires: %i[
         lua_close lua_gettable lua_gettop lua_insert lua_newtable lua_next lua_open
         lua_pcall lua_pushboolean lua_pushcclosure lua_pushnil lua_pushnumber

--- a/logic/interpreters/interpreter_54.rb
+++ b/logic/interpreters/interpreter_54.rb
@@ -12,11 +12,11 @@ module Logic
 
       # lua_isinteger lua_pushinteger lua_tointeger
       requires: %i[
-        lua_close lua_createtable lua_getfield lua_getglobal lua_gettop lua_next
-        lua_pcall lua_pushboolean lua_pushcclosure lua_pushnil lua_pushnumber
-        lua_pushstring lua_rawgeti lua_setglobal lua_settable lua_settop lua_toboolean
-        lua_tonumber lua_topointer lua_tostring lua_type lua_typename luaL_loadfile
-        luaL_loadstring luaL_newstate luaL_openlibs luaL_ref
+        lua_close lua_createtable lua_getfield lua_gettop lua_next lua_pcall
+        lua_pushboolean lua_pushcclosure lua_pushnil lua_pushnumber lua_pushstring
+        lua_rawgeti lua_settable lua_settop lua_toboolean lua_tonumber lua_topointer
+        lua_tostring lua_type lua_typename luaL_loadfile luaL_loadstring luaL_newstate
+        luaL_openlibs luaL_ref lua_getglobal lua_setglobal
       ],
 
       status: {

--- a/spec/versions/401_spec.rb
+++ b/spec/versions/401_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe 'Lua 4.0.1' do
     end
   end
 
+  context 'nil state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['4.0.1']['shared_object'])
+
+      expect(state.get('nope')).to eq(nil)
+      expect(state.set('a?', 1)).to eq(nil)
+      expect(state.get('a?')).to eq(1)
+
+      expect(state.set(:a, 'a  b')).to eq(nil)
+      expect(state.get(:a)).to eq('a  b')
+    end
+  end
+
   context 'state', skip: true do
     it do
       config = YAML.load_file('config/tests.yml')
@@ -109,6 +124,12 @@ RSpec.describe 'Lua 4.0.1' do
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
       GC.start
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
+
+      expect(state.set(:my, {})).to eq(nil)
+      expect(state.set(:my, :a, 2)).to eq(nil)
+      expect(state.get(:my, :a)).to eq(2.0)
+      expect(state.set(:_G, :gba, 3)).to eq(nil)
+      expect(state.get(:_G, :gba)).to eq(3.0)
     end
   end
 end

--- a/spec/versions/503_spec.rb
+++ b/spec/versions/503_spec.rb
@@ -30,6 +30,21 @@ RSpec.describe do
     end
   end
 
+  context 'nil state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['5.0.3']['shared_object'])
+
+      expect(state.get('nope')).to eq(nil)
+      expect(state.set('a?', 1)).to eq(nil)
+      expect(state.get('a?')).to eq(1)
+
+      expect(state.set(:a, 'a  b')).to eq(nil)
+      expect(state.get(:a)).to eq('a  b')
+    end
+  end
+
   context 'state' do
     it do
       config = YAML.load_file('config/tests.yml')
@@ -124,6 +139,12 @@ RSpec.describe do
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
       GC.start
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
+
+      expect(state.set(:my, {})).to eq(nil)
+      expect(state.set(:my, :a, 2)).to eq(nil)
+      expect(state.get(:my, :a)).to eq(2.0)
+      expect(state.set(:_G, :gba, 3)).to eq(nil)
+      expect(state.get(:_G, :gba)).to eq(3.0)
     end
   end
 end

--- a/spec/versions/515_spec.rb
+++ b/spec/versions/515_spec.rb
@@ -112,9 +112,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
-      expect(state.fennel.set('a/b', 3)).to eq(nil)
-      expect(state.fennel.get('a/b')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+      expect(state.fennel.set('a/b?', 3)).to eq(nil)
+      expect(state.fennel.get('a/b?')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
+      expect(state.fennel.eval('a/b?')).to eq(3.0)
 
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.1')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on Lua 5.1')

--- a/spec/versions/515_spec.rb
+++ b/spec/versions/515_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
+      expect(state.fennel.set('a/b', 3)).to eq(nil)
+      expect(state.fennel.get('a/b')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.1')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on Lua 5.1')
 

--- a/spec/versions/515_spec.rb
+++ b/spec/versions/515_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe do
     end
   end
 
+  context 'nil state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['5.1.5']['shared_object'])
+
+      expect(state.get('nope')).to eq(nil)
+      expect(state.set('a?', 1)).to eq(nil)
+      expect(state.get('a?')).to eq(1)
+
+      expect(state.set(:a, 'a  b')).to eq(nil)
+      expect(state.get(:a)).to eq('a  b')
+    end
+  end
+
   context 'state' do
     it do
       config = YAML.load_file('config/tests.yml')
@@ -114,8 +129,7 @@ RSpec.describe do
 
       expect(state.fennel.set('a/b?', 3)).to eq(nil)
       expect(state.fennel.get('a/b?')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
-      expect(state.fennel.eval('a/b?')).to eq(3.0)
+      expect(state.fennel.eval('_G.a/b?')).to eq(3.0)
 
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.1')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on Lua 5.1')
@@ -124,6 +138,12 @@ RSpec.describe do
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
       GC.start
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
+
+      expect(state.set(:my, {})).to eq(nil)
+      expect(state.set(:my, :a, 2)).to eq(nil)
+      expect(state.get(:my, :a)).to eq(2.0)
+      expect(state.set(:_G, :gba, 3)).to eq(nil)
+      expect(state.get(:_G, :gba)).to eq(3.0)
     end
   end
 end

--- a/spec/versions/524_spec.rb
+++ b/spec/versions/524_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe do
     end
   end
 
+  context 'nil state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['5.2.4']['shared_object'])
+
+      expect(state.get('nope')).to eq(nil)
+      expect(state.set('a?', 1)).to eq(nil)
+      expect(state.get('a?')).to eq(1)
+
+      expect(state.set(:a, 'a  b')).to eq(nil)
+      expect(state.get(:a)).to eq('a  b')
+    end
+  end
+
   context 'state' do
     it do
       config = YAML.load_file('config/tests.yml')
@@ -113,8 +128,7 @@ RSpec.describe do
 
       expect(state.fennel.set('a/b?', 3)).to eq(nil)
       expect(state.fennel.get('a/b?')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
-      expect(state.fennel.eval('a/b?')).to eq(3.0)
+      expect(state.fennel.eval('_G.a/b?')).to eq(3.0)
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.2')
@@ -124,6 +138,12 @@ RSpec.describe do
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
       GC.start
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
+
+      expect(state.set(:my, {})).to eq(nil)
+      expect(state.set(:my, :a, 2)).to eq(nil)
+      expect(state.get(:my, :a)).to eq(2.0)
+      expect(state.set(:_G, :gba, 3)).to eq(nil)
+      expect(state.get(:_G, :gba)).to eq(3.0)
     end
   end
 end

--- a/spec/versions/524_spec.rb
+++ b/spec/versions/524_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
+      expect(state.fennel.set('a/b', 3)).to eq(nil)
+      expect(state.fennel.get('a/b')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.2')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on Lua 5.2')

--- a/spec/versions/524_spec.rb
+++ b/spec/versions/524_spec.rb
@@ -111,9 +111,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
-      expect(state.fennel.set('a/b', 3)).to eq(nil)
-      expect(state.fennel.get('a/b')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+      expect(state.fennel.set('a/b?', 3)).to eq(nil)
+      expect(state.fennel.get('a/b?')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
+      expect(state.fennel.eval('a/b?')).to eq(3.0)
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.2')

--- a/spec/versions/533_spec.rb
+++ b/spec/versions/533_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe do
     end
   end
 
+  context 'nil state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['5.3.3']['shared_object'])
+
+      expect(state.get('nope')).to eq(nil)
+      expect(state.set('a?', 1)).to eq(nil)
+      expect(state.get('a?')).to eq(1)
+
+      expect(state.set(:a, 'a  b')).to eq(nil)
+      expect(state.get(:a)).to eq('a  b')
+    end
+  end
+
   context 'state' do
     it do
       config = YAML.load_file('config/tests.yml')
@@ -114,8 +129,7 @@ RSpec.describe do
 
       expect(state.fennel.set('a/b?', 3)).to eq(nil)
       expect(state.fennel.get('a/b?')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
-      expect(state.fennel.eval('a/b?')).to eq(3.0)
+      expect(state.fennel.eval('_G.a/b?')).to eq(3.0)
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.3')
@@ -125,6 +139,12 @@ RSpec.describe do
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
       GC.start
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
+
+      expect(state.set(:my, {})).to eq(nil)
+      expect(state.set(:my, :a, 2)).to eq(nil)
+      expect(state.get(:my, :a)).to eq(2.0)
+      expect(state.set(:_G, :gba, 3)).to eq(nil)
+      expect(state.get(:_G, :gba)).to eq(3.0)
     end
   end
 end

--- a/spec/versions/533_spec.rb
+++ b/spec/versions/533_spec.rb
@@ -112,6 +112,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
+      expect(state.fennel.set('a/b', 3)).to eq(nil)
+      expect(state.fennel.get('a/b')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.3')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on Lua 5.3')

--- a/spec/versions/533_spec.rb
+++ b/spec/versions/533_spec.rb
@@ -112,9 +112,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
-      expect(state.fennel.set('a/b', 3)).to eq(nil)
-      expect(state.fennel.get('a/b')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+      expect(state.fennel.set('a/b?', 3)).to eq(nil)
+      expect(state.fennel.get('a/b?')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
+      expect(state.fennel.eval('a/b?')).to eq(3.0)
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.3')

--- a/spec/versions/544_spec.rb
+++ b/spec/versions/544_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
+      expect(state.fennel.set('a/b', 3)).to eq(nil)
+      expect(state.fennel.get('a/b')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.4')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on Lua 5.4')

--- a/spec/versions/544_spec.rb
+++ b/spec/versions/544_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe do
     end
   end
 
+  context 'nil state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['5.4.4']['shared_object'])
+
+      expect(state.get('nope')).to eq(nil)
+      expect(state.set('a?', 1)).to eq(nil)
+      expect(state.get('a?')).to eq(1)
+
+      expect(state.set(:a, 'a  b')).to eq(nil)
+      expect(state.get(:a)).to eq('a  b')
+    end
+  end
+
   context 'state' do
     it do
       config = YAML.load_file('config/tests.yml')
@@ -113,8 +128,7 @@ RSpec.describe do
 
       expect(state.fennel.set('a/b?', 3)).to eq(nil)
       expect(state.fennel.get('a/b?')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
-      expect(state.fennel.eval('a/b?')).to eq(3.0)
+      expect(state.fennel.eval('_G.a/b?')).to eq(3.0)
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.4')
@@ -133,6 +147,30 @@ RSpec.describe do
       GC.start
 
       expect(from_lua.([2, 3])).to eq(5)
+
+      expect(state.set(:my, {})).to eq(nil)
+      expect(state.set(:my, :a, 2)).to eq(nil)
+      expect(state.get(:my, :a)).to eq(2.0)
+      expect(state.set(:_G, :gba, 3)).to eq(nil)
+      expect(state.get(:_G, :gba)).to eq(3.0)
+    end
+  end
+
+  context 'state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['5.4.4']['shared_object'])
+
+      expect(state.add_package_path(config['fennel-dev'])).to eq(nil)
+
+      expect(state.fennel.eval('(set _G.a? 3)')).to eq(nil)
+      expect(state.fennel.eval('_G.a?')).to eq(3)
+
+      expect(state.fennel.set(:c?, 4)).to eq(nil)
+      expect(state.fennel.get(:c?)).to eq(4)
+      expect(state.fennel.eval('c?')).to eq(nil)
+      expect(state.fennel.eval('_G.c?')).to eq(4)
     end
   end
 end

--- a/spec/versions/544_spec.rb
+++ b/spec/versions/544_spec.rb
@@ -111,9 +111,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
-      expect(state.fennel.set('a/b', 3)).to eq(nil)
-      expect(state.fennel.get('a/b')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+      expect(state.fennel.set('a/b?', 3)).to eq(nil)
+      expect(state.fennel.get('a/b?')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
+      expect(state.fennel.eval('a/b?')).to eq(3.0)
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on Lua 5.4')

--- a/spec/versions/jit_205_spec.rb
+++ b/spec/versions/jit_205_spec.rb
@@ -112,9 +112,10 @@ RSpec.describe do
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
 
-      expect(state.fennel.set('a/b', 3)).to eq(nil)
-      expect(state.fennel.get('a/b')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+      expect(state.fennel.set('a/b?', 3)).to eq(nil)
+      expect(state.fennel.get('a/b?')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
+      expect(state.fennel.eval('a/b?')).to eq(3.0)
 
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on LuaJIT 2.0.5 (Lua 5.1)')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on LuaJIT 2.0.5 (Lua 5.1)')

--- a/spec/versions/jit_205_spec.rb
+++ b/spec/versions/jit_205_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe do
     end
   end
 
+  context 'nil state' do
+    it do
+      config = YAML.load_file('config/tests.yml')
+
+      state = SweetMoon::State.new(shared_object: config['jit:2.0.5']['shared_object'])
+
+      expect(state.get('nope')).to eq(nil)
+      expect(state.set('a?', 1)).to eq(nil)
+      expect(state.get('a?')).to eq(1)
+
+      expect(state.set(:a, 'a  b')).to eq(nil)
+      expect(state.get(:a)).to eq('a  b')
+    end
+  end
+
   context 'state' do
     it do
       config = YAML.load_file('config/tests.yml')
@@ -114,8 +129,7 @@ RSpec.describe do
 
       expect(state.fennel.set('a/b?', 3)).to eq(nil)
       expect(state.fennel.get('a/b?')).to eq(3.0)
-      expect(state.fennel.get('__fnl_global__a_2fb_3f')).to eq(3.0)
-      expect(state.fennel.eval('a/b?')).to eq(3.0)
+      expect(state.fennel.eval('_G.a/b?')).to eq(3.0)
 
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on LuaJIT 2.0.5 (Lua 5.1)')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on LuaJIT 2.0.5 (Lua 5.1)')
@@ -124,6 +138,12 @@ RSpec.describe do
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
       GC.start
       expect(state.eval('return gcSum(1, 2)')).to eq(3.0)
+
+      expect(state.set(:my, {})).to eq(nil)
+      expect(state.set(:my, :a, 2)).to eq(nil)
+      expect(state.get(:my, :a)).to eq(2.0)
+      expect(state.set(:_G, :gba, 3)).to eq(nil)
+      expect(state.get(:_G, :gba)).to eq(3.0)
     end
   end
 

--- a/spec/versions/jit_205_spec.rb
+++ b/spec/versions/jit_205_spec.rb
@@ -111,6 +111,11 @@ RSpec.describe do
       expect(state.add_package_path(config['jit:2.0.5']['fennel'])).to eq(nil)
 
       expect(state.fennel.eval('(+ 1 2)')).to eq(3.0)
+
+      expect(state.fennel.set('a/b', 3)).to eq(nil)
+      expect(state.fennel.get('a/b')).to eq(3.0)
+      expect(state.fennel.get('__fnl_global__a_2fb')).to eq(3.0)
+
       expect(state.fennel.meta.runtime).to eq('Fennel 1.0.0 on LuaJIT 2.0.5 (Lua 5.1)')
       expect(state.fennel.meta.to_h[:runtime]).to eq('Fennel 1.0.0 on LuaJIT 2.0.5 (Lua 5.1)')
 


### PR DESCRIPTION
Lua doesn't accept `/`, `-`, `?`, etc. in variable names. Fennel does.

```ruby
state.fennel.set('a/b?', 3)

state.fennel.get('a/b?') # => 3

state.fennel.eval('a/b?') # => 3
```