### PR TITLE
Global FFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1364,7 +1364,7 @@ Update the [`config/tests.yml`](https://github.com/gbaptista/sweet-moon/blob/mai
 
 Alternatively: Find or build the _Shared Objects_ for your Operating System on your own.
 
-Install the expected luarocks described in `config/tests.yml`.
+Install the expected Lua _rocks_ described in `config/tests.yml`.
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -1364,6 +1364,8 @@ Update the [`config/tests.yml`](https://github.com/gbaptista/sweet-moon/blob/mai
 
 Alternatively: Find or build the _Shared Objects_ for your Operating System on your own.
 
+Install the expected luarocks described in `config/tests.yml`.
+
 ### Running
 
 ```sh

--- a/components/api.rb
+++ b/components/api.rb
@@ -2,7 +2,7 @@ require 'ffi'
 
 module Component
   API = {
-    open!: ->(shared_objects) {
+    open!: ->(shared_objects, options = {}, default = {}) {
       api = Module.new
 
       api.extend FFI::Library
@@ -10,8 +10,11 @@ module Component
       # TODO: Lua Constants
       # attach_variable
 
-      if shared_objects.size > 1
-        # TODO: Dangerous
+      global_ffi = default[:global_ffi]
+
+      global_ffi = options[:global_ffi] unless options[:global_ffi].nil?
+
+      if global_ffi
         api.ffi_lib_flags(:global, :now)
       else
         api.ffi_lib_flags(:local, :now)

--- a/components/default.rb
+++ b/components/default.rb
@@ -1,0 +1,19 @@
+require 'singleton'
+
+module Component
+  class Default
+    include Singleton
+
+    def initialize
+      @config = { global_ffi: true }
+    end
+
+    def options
+      @config
+    end
+
+    def set(key, value)
+      @config[key.to_sym] = value
+    end
+  end
+end

--- a/components/default.rb
+++ b/components/default.rb
@@ -4,16 +4,14 @@ module Component
   class Default
     include Singleton
 
-    def initialize
-      @config = { global_ffi: true }
-    end
+    attr_reader :options
 
-    def options
-      @config
+    def initialize
+      @options = { global_ffi: true }
     end
 
     def set(key, value)
-      @config[key.to_sym] = value
+      @options[key.to_sym] = value
     end
   end
 end

--- a/components/interpreters/50/function.rb
+++ b/components/interpreters/50/function.rb
@@ -4,16 +4,16 @@ module Component
   module V50
     Function = Component::V54::Function
 
-    LUA_HANDLER = <<LUA
-    return function (...)
-      result = _ruby(unpack(arg))
+    LUA_HANDLER = <<~LUA
+      return function (...)
+        result = _ruby(unpack(arg))
 
-      if result['error'] then
-        error(result['output'])
-      else
-        return result['output']
+        if result['error'] then
+          error(result['output'])
+        else
+          return result['output']
+        end
       end
-    end
-LUA
+    LUA
   end
 end

--- a/components/interpreters/54/function.rb
+++ b/components/interpreters/54/function.rb
@@ -96,16 +96,16 @@ module Component
       }
     }
 
-    LUA_HANDLER = <<LUA
-    return function (...)
-      result = _ruby(...)
+    LUA_HANDLER = <<~LUA
+      return function (...)
+        result = _ruby(...)
 
-      if result['error'] then
-        error(result['output'] .. ' ' .. debug.traceback())
-      else
-        return result['output']
+        if result['error'] then
+          error(result['output'] .. ' ' .. debug.traceback())
+        else
+          return result['output']
+        end
       end
-    end
-LUA
+    LUA
   end
 end

--- a/config/tests.sample.yml
+++ b/config/tests.sample.yml
@@ -3,11 +3,12 @@
 fennel-dev: '/home/me/sweet-moon-test/fennel/dev/?.lua'
 
 luarocks:
+  expected: ['dkjson', 'supernova', 'readline']
   path:
     - /home/me/.luarocks/share/lua/5.4/?.lua
     - /home/me/.luarocks/share/lua/5.4/?/init.lua
+  cpath:
     - /home/me/.luarocks/lib/lua/5.4/?.so
-  expected: ['supernova', 'dkjson', 'lfs']
 
 jit:2.0.5:
   description: 'Lua Jit 2.0.5 + Fennel 1.0.0'

--- a/controllers/api.rb
+++ b/controllers/api.rb
@@ -1,5 +1,6 @@
 require_relative '../components/injections'
 require_relative '../components/api'
+require_relative '../components/default'
 require_relative '../components/io'
 require_relative '../dsl/errors'
 
@@ -11,7 +12,9 @@ module Controller
     handle!: ->(options) {
       shared_objects = API[:elect_shared_objects!].(options[:shared_objects])
 
-      api = Component::API[:open!].(shared_objects)
+      api = Component::API[:open!].(
+        shared_objects, options, Component::Default.instance.options
+      )
 
       api_reference = API[:elect_api_reference!].(
         api.ffi_libraries, options[:api_reference]

--- a/dsl/api.rb
+++ b/dsl/api.rb
@@ -1,3 +1,5 @@
+require_relative '../components/default'
+
 module DSL
   class Api
     attr_reader :functions, :meta
@@ -7,11 +9,29 @@ module DSL
 
       @functions = @component[:signatures].keys
 
-      @meta = Struct.new(
-        *@component[:meta][:elected].keys
-      ).new(*@component[:meta][:elected].values)
+      build_meta
 
       extend @component[:api]
+    end
+
+    def build_global_ffi
+      global_ffi = Component::Default.instance.options[:global_ffi]
+
+      unless @component[:meta][:options][:global_ffi].nil?
+        global_ffi = @component[:meta][:options][:global_ffi]
+      end
+
+      global_ffi
+    end
+
+    def build_meta
+      meta_data = @component[:meta][:elected].clone
+
+      meta_data[:global_ffi] = build_global_ffi
+
+      @meta = Struct.new(
+        *meta_data.keys
+      ).new(*meta_data.values)
     end
 
     def signature_for(function)

--- a/dsl/cache.rb
+++ b/dsl/cache.rb
@@ -7,112 +7,126 @@ require_relative '../controllers/state'
 require_relative 'api'
 require_relative 'sweet_moon'
 
-class Cache
-  include Singleton
+module DSL
+  class Cache
+    include Singleton
 
-  def clear_global!
-    @cache[:global_state]&._unsafely_destroy
+    API_KEYS = %i[shared_objects api_reference global_ffi]
+    STATE_KEYS = %i[interpreter package_path package_cpath]
 
-    @cache.each_key { |key| @cache.delete(key) if key[/^global/] }
-  end
-
-  def keys
-    @cache.keys
-  end
-
-  def initialize
-    @cache = {}
-  end
-
-  def global_state(options = {}, recreate: false)
-    key = :global_state
-
-    clear_global_state_cache!(options) if recreate
-
-    return @cache[key] if @cache[key]
-
-    api = Cache.instance.api_module(options, :global_api_module)
-    interpreter = Cache.instance.interpreter_module(
-      api, options, :global_interpreter_module
-    )
-
-    @cache[key] = DSL::State.new(api, interpreter, Controller::State, options)
-    @cache[key].instance_eval('undef :destroy', __FILE__, __LINE__)
-
-    @cache[key]
-  end
-
-  def global_api(options = {}, recreate: false)
-    key = :global_api
-
-    clear_global_api_cache! if recreate
-
-    @cache[key] ||= api(options, :global_api, :global_api_module)
-  end
-
-  def api(options = {}, key = nil, api_module_key = nil)
-    key ||= cache_key_for(:api, options, %i[shared_objects api_reference])
-    @cache[key] ||= DSL::Api.new(api_module(options, api_module_key))
-  end
-
-  def api_module(options = {}, key = nil)
-    key ||= cache_key_for(:api_module, options, %i[shared_objects api_reference])
-    @cache[key] ||= Controller::API[:handle!].(options)
-  end
-
-  def interpreter_module(api, options = {}, key = nil)
-    key ||= cache_key_for(
-      :interpreter_module,
-      { shared_objects: api[:meta][:elected][:shared_objects],
-        api_reference: api[:meta][:elected][:api_reference],
-        interpreter: options[:interpreter], package_path: options[:package_path],
-        package_cpath: options[:package_cpath] },
-      %i[shared_objects api_reference interpreter package_path package_cpath]
-    )
-
-    @cache[key] ||= Controller::Interpreter[:handle!].(api, options)
-  end
-
-  private
-
-  def clear_global_api_cache!
-    @cache[:global_state]&._unsafely_destroy
-
-    %i[global_api global_api_module
-       global_interpreter_module
-       global_state].each do |key|
-      @cache.delete(key)
-    end
-  end
-
-  def clear_global_state_cache!(options)
-    @cache[:global_state]&._unsafely_destroy
-
-    %i[global_interpreter_module global_state].each do |key|
-      @cache.delete(key)
+    def api_keys?(options)
+      API_KEYS.each { |key| return true if options.key?(key) }
+      false
     end
 
-    return unless options.key?(:shared_objects) || options.key?(:api_reference)
-
-    %i[global_api global_api_module].each do |key|
-      @cache.delete(key)
+    def state_keys?(options)
+      STATE_KEYS.each { |key| return true if options.key?(key) }
+      false
     end
 
-    global_api(options, recreate: true)
-  end
+    def clear_global!
+      @cache[:global_state]&._unsafely_destroy
 
-  def cache_key_for(prefix, options = {}, relevant_keys = [])
-    values = [prefix]
+      @cache.each_key { |key| @cache.delete(key) if key[/^global/] }
+    end
 
-    relevant_keys.each do |key|
-      value = options[key] || options[key.to_s]
-      if value.is_a?(Array)
-        values << value.sort.join(':')
-      elsif value
-        values << value
+    def keys
+      @cache.keys
+    end
+
+    def initialize
+      @cache = {}
+    end
+
+    def global_state(options = {}, recreate: false)
+      key = :global_state
+
+      clear_global_state_cache!(options) if recreate
+
+      return @cache[key] if @cache[key]
+
+      api = Cache.instance.api_module(options, :global_api_module)
+      interpreter = Cache.instance.interpreter_module(
+        api, options, :global_interpreter_module
+      )
+
+      @cache[key] = DSL::State.new(api, interpreter, Controller::State, options)
+      @cache[key].instance_eval('undef :destroy', __FILE__, __LINE__)
+
+      @cache[key]
+    end
+
+    def global_api(options = {}, recreate: false)
+      key = :global_api
+
+      clear_global_api_cache! if recreate
+
+      @cache[key] ||= api(options, :global_api, :global_api_module)
+    end
+
+    def api(options = {}, key = nil, api_module_key = nil)
+      key ||= cache_key_for(:api, options, API_KEYS)
+      @cache[key] ||= DSL::Api.new(api_module(options, api_module_key))
+    end
+
+    def api_module(options = {}, key = nil)
+      key ||= cache_key_for(:api_module, options, API_KEYS)
+      @cache[key] ||= Controller::API[:handle!].(options)
+    end
+
+    def interpreter_module(api, options = {}, key = nil)
+      key ||= cache_key_for(
+        :interpreter_module,
+        { shared_objects: api[:meta][:elected][:shared_objects],
+          api_reference: api[:meta][:elected][:api_reference],
+          global_ffi: api[:meta][:global_ffi],
+          interpreter: options[:interpreter], package_path: options[:package_path],
+          package_cpath: options[:package_cpath] },
+        API_KEYS.concat(STATE_KEYS)
+      )
+
+      @cache[key] ||= Controller::Interpreter[:handle!].(api, options)
+    end
+
+    def cache_key_for(prefix, options = {}, relevant_keys = [])
+      values = [prefix]
+
+      relevant_keys.each do |key|
+        value = options[key]
+        value = options[key.to_s] if value.nil?
+
+        values << (value.is_a?(Array) ? value.sort.join(':') : value.inspect)
+      end
+
+      values.join('|')
+    end
+
+    private
+
+    def clear_global_api_cache!
+      @cache[:global_state]&._unsafely_destroy
+
+      %i[global_api global_api_module
+         global_interpreter_module
+         global_state].each do |key|
+        @cache.delete(key)
       end
     end
 
-    values.join('|')
+    def clear_global_state_cache!(options)
+      @cache[:global_state]&._unsafely_destroy
+
+      %i[global_interpreter_module global_state].each do |key|
+        @cache.delete(key)
+      end
+
+      return unless api_keys?(options)
+
+      %i[global_api global_api_module].each do |key|
+        @cache.delete(key)
+      end
+
+      global_api(options, recreate: true)
+    end
   end
 end

--- a/dsl/global.rb
+++ b/dsl/global.rb
@@ -2,41 +2,40 @@ require_relative '../logic/options'
 
 require_relative 'cache'
 
-module Global
-  def api
-    Cache.instance.global_api
-  end
-
-  def state
-    Cache.instance.global_state
-  end
-
-  def config(options = {})
-    options = Logic::Options[:normalize].(options)
-
-    if options.key?(:shared_objects) || options.key?(:api_reference)
-      Cache.instance.global_api(options, recreate: true)
+module DSL
+  module Global
+    def api
+      Cache.instance.global_api
     end
 
-    return unless
-      options.key?(:interpreter) ||
-      options.key?(:package_path) ||
-      options.key?(:package_cpath)
+    def state
+      Cache.instance.global_state
+    end
 
-    Cache.instance.global_state(options, recreate: true)
+    def config(options = {})
+      options = Logic::Options[:normalize].(options)
 
-    nil
+      if Cache.instance.api_keys?(options)
+        Cache.instance.global_api(options, recreate: true)
+      end
+
+      return unless Cache.instance.state_keys?(options)
+
+      Cache.instance.global_state(options, recreate: true)
+
+      nil
+    end
+
+    def cached(all: false)
+      return Cache.instance.keys if all
+
+      Cache.instance.keys.select { |key| key[/^global/] }
+    end
+
+    def clear
+      Cache.instance.clear_global!
+    end
+
+    module_function :api, :state, :config, :cached, :clear
   end
-
-  def cached(all: false)
-    return Cache.instance.keys if all
-
-    Cache.instance.keys.select { |key| key[/^global/] }
-  end
-
-  def clear
-    Cache.instance.clear_global!
-  end
-
-  module_function :api, :state, :config, :cached, :clear
 end

--- a/dsl/state.rb
+++ b/dsl/state.rb
@@ -1,6 +1,7 @@
 require_relative 'errors'
 require_relative 'concerns/packages'
 require_relative 'concerns/fennel'
+require_relative '../components/default'
 
 module DSL
   class State
@@ -87,13 +88,25 @@ module DSL
 
     private
 
-    def build_meta(api_component, interpreter_component)
-      meta_data = {
+    def build_api_meta(api_component)
+      global_ffi = Component::Default.instance.options[:global_ffi]
+
+      unless api_component[:meta][:options][:global_ffi].nil?
+        global_ffi = api_component[:meta][:options][:global_ffi]
+      end
+
+      {
         api_reference: api_component[:meta][:elected][:api_reference],
         shared_objects: api_component[:meta][:elected][:shared_objects],
-        interpreter: interpreter_component[:meta][:elected][:interpreter],
-        runtime: interpreter_component[:meta][:runtime][:lua]
+        global_ffi: global_ffi
       }
+    end
+
+    def build_meta(api_component, interpreter_component)
+      meta_data = build_api_meta(api_component)
+
+      meta_data[:interpreter] = interpreter_component[:meta][:elected][:interpreter]
+      meta_data[:runtime] = interpreter_component[:meta][:runtime][:lua]
 
       @meta = Struct.new(*meta_data.keys).new(*meta_data.values)
     end

--- a/dsl/sweet_moon.rb
+++ b/dsl/sweet_moon.rb
@@ -11,7 +11,7 @@ require_relative '../logic/interpreter'
 module SweetMoon
   module API
     def new(options = {})
-      Cache.instance.api(Logic::Options[:normalize].(options))
+      DSL::Cache.instance.api(Logic::Options[:normalize].(options))
     end
 
     module_function :new
@@ -21,9 +21,9 @@ module SweetMoon
     def new(options = {})
       options = Logic::Options[:normalize].(options)
 
-      api = Cache.instance.api_module(options)
+      api = DSL::Cache.instance.api_module(options)
 
-      interpreter = Cache.instance.interpreter_module(api, options)
+      interpreter = DSL::Cache.instance.interpreter_module(api, options)
 
       DSL::State.new(api, interpreter, Controller::State, options)
     end
@@ -46,7 +46,7 @@ module SweetMoon
   end
 
   def global
-    Global
+    DSL::Global
   end
 
   module_function :meta, :global

--- a/spec/dsl/api_spec.rb
+++ b/spec/dsl/api_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe do
       api = DSL::Api.new(component)
 
       expect(api.meta.to_h).to eq(
-        shared_objects: [config['shared_object']], api_reference: '5.4.2'
+        shared_objects: [config['shared_object']], api_reference: '5.4.2',
+        global_ffi: false
       )
 
       expect(api.functions.size).to be > 150
@@ -38,7 +39,8 @@ RSpec.describe do
       api = DSL::Api.new(component)
 
       expect(api.meta.to_h).to eq(
-        shared_objects: [config['shared_object']], api_reference: '3.2.2'
+        shared_objects: [config['shared_object']], api_reference: '3.2.2',
+        global_ffi: false
       )
 
       expect(api.functions.size).to be > 150

--- a/spec/dsl/cache_spec.rb
+++ b/spec/dsl/cache_spec.rb
@@ -1,0 +1,14 @@
+require './dsl/cache'
+
+RSpec.describe do
+  context 'cache' do
+    it do
+      expect(DSL::Cache.instance.cache_key_for(
+               :api_module,
+               { global_ffi: false, shared_objects: ['/liblua.so'] },
+               %i[shared_objects api_reference global_ffi
+                  interpreter package_path package_cpath]
+             )).to eq('api_module|/liblua.so|nil|false|nil|nil|nil')
+    end
+  end
+end

--- a/spec/dsl/data_types_spec.rb
+++ b/spec/dsl/data_types_spec.rb
@@ -20,25 +20,12 @@ RSpec.describe do
 
       expect(state.eval('return 1 + 1')).to eq(2)
 
-      expect(fennel.keys.sort).to eq(
-        ['comment', 'comment?', 'compile', 'compile-stream', 'compile-string',
-         'compile1', 'compileStream', 'compileString', 'doc', 'dofile', 'eval',
-         'gensym', 'granulate', 'list', 'list?', 'load-code', 'loadCode',
-         'macro-loaded', 'macro-path', 'macro-searchers', 'macroLoaded',
-         'make-searcher', 'makeSearcher', 'make_searcher', 'mangle', 'metadata',
-         'parser', 'path', 'repl', 'scope', 'search-module', 'searchModule',
-         'searcher', 'sequence', 'sequence?', 'string-stream', 'stringStream',
-         'sym', 'sym-char?', 'sym?', 'syntax', 'traceback', 'unmangle', 'varg',
-         'version', 'view']
-      )
+      expect(fennel.keys).to include(*%w[dofile eval repl version view])
 
       expect(state.eval('return 1 + 1')).to eq(2)
 
-      expect(fennel.values.map(&:class).map(&:to_s).sort).to eq(
-        %w[Array Hash Hash Hash Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc
-           Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc
-           Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc String
-           String String]
+      expect(fennel.values.map(&:class).map(&:to_s)).to include(
+        *%w[Array Hash Proc String String String]
       )
 
       expect(state.eval('return 1 + 1')).to eq(2)
@@ -59,32 +46,15 @@ RSpec.describe do
 
       expect(state.eval('return 1 + 1')).to eq(2)
 
-      expect(supernova.keys.sort).to eq(
-        %w[active_theme apply_command chain colors disable enable enabled get-theme
-           get_theme handlers init is_controller set-colors set-theme set_colors
-           set_theme styles]
-      )
+      expect(supernova.keys).to include(*%w[enable set-colors set-theme])
 
       expect(state.eval('return 1 + 1')).to eq(2)
 
-      expect(supernova.values.map(&:class).map(&:to_s).sort).to eq(
-        %w[Hash Hash Hash Proc Proc Proc Proc Proc Proc Proc Proc Proc Proc String
-           String TrueClass TrueClass]
+      expect(supernova.values.map(&:class).map(&:to_s)).to include(
+        *%w[Hash Proc String TrueClass]
       )
 
       expect(state.eval('return 1 + 1')).to eq(2)
-    end
-  end
-
-  context 'lfs', skip: true do
-    it do
-      config = YAML.load_file('config/tests.yml')
-
-      state = SweetMoon::State.new(shared_object: config['5.4.2']['shared_object'])
-
-      config['luarocks']['path'].each { |path| state.add_package_path(path) }
-
-      state.eval('lfs = require("lfs")')
     end
   end
 
@@ -102,15 +72,11 @@ RSpec.describe do
 
       expect(state.eval('return 1 + 1')).to eq(2)
 
-      expect(dkjson.keys.sort).to eq(
-        %w[addnewline decode encode encodeexception null quotestring use_lpeg version]
-      )
+      expect(dkjson.keys).to include(*%w[decode encode])
 
       expect(state.eval('return 1 + 1')).to eq(2)
 
-      expect(dkjson.values.map(&:class).map(&:to_s).sort).to eq(
-        %w[Hash Proc Proc Proc Proc Proc Proc String]
-      )
+      expect(dkjson.values.map(&:class).map(&:to_s)).to include(*%w[Hash Proc String])
 
       expect(state.eval('return 1 + 1')).to eq(2)
     end

--- a/spec/dsl/fennel_spec.rb
+++ b/spec/dsl/fennel_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe do
         shared_objects: [config['5.4.2']['shared_object']],
         api_reference: '5.4.2',
         interpreter: '5.4',
-        runtime: 'Fennel 1.0.0 on Lua 5.4'
+        runtime: 'Fennel 1.0.0 on Lua 5.4',
+        global_ffi: false
       )
 
       expect(fennel.eval('(+ 1 1)')).to eq(2)
@@ -33,7 +34,8 @@ RSpec.describe do
         api_reference: '5.4.2',
         interpreter: '5.4',
         runtime: 'Fennel 1.0.0 on Lua 5.4',
-        shared_objects: [config['5.4.2']['shared_object']]
+        shared_objects: [config['5.4.2']['shared_object']],
+        global_ffi: false
       )
 
       expect(fennel.meta.api_reference).to eq('5.4.2')
@@ -62,7 +64,8 @@ RSpec.describe do
         shared_objects: [config['5.4.2']['shared_object']],
         api_reference: '5.4.2',
         interpreter: '5.4',
-        runtime: 'Fennel 1.0.0 on Lua 5.4'
+        runtime: 'Fennel 1.0.0 on Lua 5.4',
+        global_ffi: false
       )
 
       expect(fennel.eval('(+ 1 1)')).to eq(2)
@@ -77,7 +80,8 @@ RSpec.describe do
         api_reference: '5.4.2',
         interpreter: '5.4',
         runtime: 'Fennel 1.0.0 on Lua 5.4',
-        shared_objects: [config['5.4.2']['shared_object']]
+        shared_objects: [config['5.4.2']['shared_object']],
+        global_ffi: false
       )
 
       expect(fennel.meta.api_reference).to eq('5.4.2')

--- a/spec/dsl/ffi_global_spec.rb
+++ b/spec/dsl/ffi_global_spec.rb
@@ -1,0 +1,102 @@
+require 'yaml'
+
+require './dsl/sweet_moon'
+
+RSpec.describe do
+  context 'readline' do
+    context 'isolated state', skip: true do
+      it do
+        SweetMoon.global.clear
+
+        config = YAML.load_file('config/tests.yml')
+
+        SweetMoon.global.config(shared_object: config['5.4.2']['shared_object'])
+
+        expect(SweetMoon.global.api.meta.to_h).to eq(
+          api_reference: '5.4.2',
+          shared_objects: [config['5.4.2']['shared_object']],
+          global_ffi: false
+        )
+
+        state = SweetMoon::State.new(
+          shared_object: config['5.4.2']['shared_object'],
+          global_ffi: true
+        )
+
+        config['luarocks']['path'].each { |path| state.add_package_path(path) }
+        config['luarocks']['cpath'].each { |path| state.add_package_cpath(path) }
+
+        expect(state.meta.to_h).to eq(
+          api_reference: '5.4.2',
+          global_ffi: true,
+          interpreter: '5.4',
+          runtime: 'Lua 5.4',
+          shared_objects: [config['5.4.2']['shared_object']]
+        )
+
+        expect(SweetMoon.global.api.meta.to_h).to eq(
+          api_reference: '5.4.2',
+          shared_objects: [config['5.4.2']['shared_object']],
+          global_ffi: false
+        )
+
+        expect(state.eval('return require("readline")').keys).to include(
+          *%w[set_readline_name set_options readline
+              set_completion_append_character set_complete_function]
+        )
+      end
+    end
+
+    context 'isolated state error' do
+      it do
+        SweetMoon.global.clear
+
+        config = YAML.load_file('config/tests.yml')
+
+        SweetMoon.global.config(
+          shared_object: config['5.4.2']['shared_object']
+        )
+
+        expect(SweetMoon.global.api.meta.to_h).to eq(
+          api_reference: '5.4.2',
+          shared_objects: [config['5.4.2']['shared_object']],
+          global_ffi: false
+        )
+
+        expect(SweetMoon.global.state.meta.to_h).to eq(
+          api_reference: '5.4.2',
+          global_ffi: false,
+          interpreter: '5.4',
+          runtime: 'Lua 5.4',
+          shared_objects: [config['5.4.2']['shared_object']]
+        )
+
+        state = SweetMoon::State.new(
+          shared_object: config['5.4.2']['shared_object']
+        )
+
+        config['luarocks']['path'].each { |path| state.add_package_path(path) }
+        config['luarocks']['cpath'].each { |path| state.add_package_cpath(path) }
+
+        expect(state.meta.to_h).to eq(
+          api_reference: '5.4.2',
+          global_ffi: false,
+          interpreter: '5.4',
+          runtime: 'Lua 5.4',
+          shared_objects: [config['5.4.2']['shared_object']]
+        )
+
+        expect(SweetMoon.global.api.meta.to_h).to eq(
+          api_reference: '5.4.2',
+          shared_objects: [config['5.4.2']['shared_object']],
+          global_ffi: false
+        )
+
+        expect { state.eval('return require("readline")') }.to raise_error(
+          an_instance_of(SweetMoon::Errors::LuaRuntimeError),
+          /error loading module 'C-readline'/
+        )
+      end
+    end
+  end
+end

--- a/spec/dsl/meta_spec.rb
+++ b/spec/dsl/meta_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe do
 
     expect(api.meta.to_h).to eq(
       shared_objects: [config['5.4.4']['shared_object']],
-      api_reference: '5.4.2'
+      api_reference: '5.4.2',
+      global_ffi: false
     )
 
     expect(api.meta.shared_objects).to eq([config['5.4.4']['shared_object']])
@@ -24,7 +25,8 @@ RSpec.describe do
       shared_objects: [config['5.4.4']['shared_object']],
       api_reference: '5.4.2',
       interpreter: '5.4',
-      runtime: 'Lua 5.4'
+      runtime: 'Lua 5.4',
+      global_ffi: false
     )
 
     expect(state.meta.shared_objects).to eq([config['5.4.4']['shared_object']])
@@ -34,7 +36,8 @@ RSpec.describe do
 
     expect(SweetMoon.global.api.meta.to_h).to eq(
       shared_objects: [config['5.4.4']['shared_object']],
-      api_reference: '5.4.2'
+      api_reference: '5.4.2',
+      global_ffi: false
     )
 
     expect(SweetMoon.global.api.meta.shared_objects).to eq(
@@ -47,7 +50,8 @@ RSpec.describe do
       shared_objects: [config['5.4.4']['shared_object']],
       api_reference: '5.4.2',
       interpreter: '5.4',
-      runtime: 'Lua 5.4'
+      runtime: 'Lua 5.4',
+      global_ffi: false
     )
 
     expect(SweetMoon.global.state.meta.shared_objects).to eq(

--- a/spec/dsl/sweet_moon_spec.rb
+++ b/spec/dsl/sweet_moon_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe do
 
       expect(state.meta.to_h).to eq(
         api_reference: '5.4.2', interpreter: '5.4', runtime: 'Lua 5.4',
-        shared_objects: [config['5.4.4']['shared_object']]
+        shared_objects: [config['5.4.4']['shared_object']],
+        global_ffi: false
       )
 
       expect(state.meta.api_reference).to eq('5.4.2')
@@ -39,7 +40,8 @@ RSpec.describe do
 
       expect(state_b.meta.to_h).to eq(
         api_reference: '5.4.2', interpreter: '5.4', runtime: 'Lua 5.4',
-        shared_objects: [config['5.4.2']['shared_object']]
+        shared_objects: [config['5.4.2']['shared_object']],
+        global_ffi: false
       )
 
       expect(state.eval('return 1.5 + 1.5;')).to eq(3.0)
@@ -59,13 +61,15 @@ RSpec.describe do
       expect(api.signature_for(:luaH_new)).to eq(nil)
 
       expect(api.meta.to_h).to eq(
-        api_reference: '5.4.2', shared_objects: [config['5.4.4']['shared_object']]
+        api_reference: '5.4.2', shared_objects: [config['5.4.4']['shared_object']],
+        global_ffi: false
       )
 
       api_b = SweetMoon::API.new(shared_object: config['3.2.2']['shared_object'])
 
       expect(api_b.meta.to_h).to eq(
-        api_reference: '3.2.2', shared_objects: [config['3.2.2']['shared_object']]
+        api_reference: '3.2.2', shared_objects: [config['3.2.2']['shared_object']],
+        global_ffi: false
       )
 
       expect(api_b.functions.size).to be > 150
@@ -89,7 +93,8 @@ RSpec.describe do
       expect(SweetMoon.global.cached).to eq(%i[global_api_module global_api])
 
       expect(SweetMoon.global.api.meta.to_h).to eq(
-        api_reference: '5.4.2', shared_objects: [config['5.4.4']['shared_object']]
+        api_reference: '5.4.2', shared_objects: [config['5.4.4']['shared_object']],
+        global_ffi: false
       )
 
       expect(SweetMoon.global.api.functions.size).to be > 150
@@ -100,7 +105,8 @@ RSpec.describe do
       SweetMoon.global.config(shared_object: config['3.2.2']['shared_object'])
 
       expect(SweetMoon.global.api.meta.to_h).to eq(
-        api_reference: '3.2.2', shared_objects: [config['3.2.2']['shared_object']]
+        api_reference: '3.2.2', shared_objects: [config['3.2.2']['shared_object']],
+        global_ffi: false
       )
 
       expect(SweetMoon.global.api.functions.size).to be > 150

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require_relative '../components/default'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -8,4 +10,6 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  Component::Default.instance.set(:global_ffi, false)
 end

--- a/spec/versions/503_spec.rb
+++ b/spec/versions/503_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe do
         api_reference: '5.0.3',
         interpreter: '5.0',
         runtime: 'Lua 5.0.3',
-        shared_objects: [config['5.0.3']['shared_object']]
+        shared_objects: [config['5.0.3']['shared_object']],
+        global_ffi: false
       )
 
       expect(state.eval('return _VERSION')).to eq('Lua 5.0.3')

--- a/spec/versions/515_spec.rb
+++ b/spec/versions/515_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe do
         api_reference: '5.1.4',
         interpreter: '5.1',
         runtime: 'Lua 5.1',
-        shared_objects: [config['5.1.5']['shared_object']]
+        shared_objects: [config['5.1.5']['shared_object']],
+        global_ffi: false
       )
 
       expect(state.eval('return _VERSION')).to eq('Lua 5.1')

--- a/spec/versions/524_spec.rb
+++ b/spec/versions/524_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe do
         api_reference: '5.4.2',
         interpreter: '5.4',
         runtime: 'Lua 5.2',
-        shared_objects: [config['5.2.4']['shared_object']]
+        shared_objects: [config['5.2.4']['shared_object']],
+        global_ffi: false
       )
       expect(state.eval('return _VERSION')).to eq('Lua 5.2')
 

--- a/spec/versions/533_spec.rb
+++ b/spec/versions/533_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe do
         api_reference: '5.4.2',
         interpreter: '5.4',
         runtime: 'Lua 5.3',
-        shared_objects: [config['5.3.3']['shared_object']]
+        shared_objects: [config['5.3.3']['shared_object']],
+        global_ffi: false
       )
       expect(state.eval('return _VERSION')).to eq('Lua 5.3')
 

--- a/spec/versions/544_spec.rb
+++ b/spec/versions/544_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe do
         api_reference: '5.4.2',
         interpreter: '5.4',
         runtime: 'Lua 5.4',
-        shared_objects: [config['5.4.4']['shared_object']]
+        shared_objects: [config['5.4.4']['shared_object']],
+        global_ffi: false
       )
       expect(state.eval('return _VERSION')).to eq('Lua 5.4')
 

--- a/spec/versions/jit_205_spec.rb
+++ b/spec/versions/jit_205_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe do
         api_reference: '5.1.4',
         interpreter: '5.1',
         runtime: 'LuaJIT 2.0.5 (Lua 5.1)',
-        shared_objects: [config['jit:2.0.5']['shared_object']]
+        shared_objects: [config['jit:2.0.5']['shared_object']],
+        global_ffi: false
       )
       expect(state.eval('return _VERSION')).to eq('Lua 5.1')
       expect(state.eval('return jit.version')).to eq('LuaJIT 2.0.5')


### PR DESCRIPTION
Some Lua libraries (e.g., [_readline_](https://pjb.com.au/comp/lua/readline.html) and [_luafilesystem_](https://keplerproject.github.io/luafilesystem/)) require the Lua C API functions available in the global C environment.

By default, _Sweet Moon_ enables [_Global FFI_](https://github.com/ffi/ffi/wiki/Loading-Libraries#function-visibility) to reduce friction when using popular libraries.

Using distinct Lua versions simultaneously with multiple _Shared Objects_ may be dangerous in this setup: Two APIs with the same name functions could be an issue because something will be overwritten.

Also, libraries that need Lua C API functions are compiled for a specific Lua version. If you are, e.g., using _LuaJIT_ and your library expects the _Standard Lua_, you may face issues.

You can disable _Global FFI_ at any time with:

```ruby
require 'sweet-moon'

SweetMoon.global.config(global_ffi: false)

SweetMoon::State.new(global_ffi: false)

SweetMoon::API.new(global_ffi: false)
```

To check if it's enabled or not:

```ruby
require 'sweet-moon'

SweetMoon.global.api.meta.global_ffi # => true
SweetMoon.global.state.meta.global_ffi # => true

SweetMoon::API.new.meta.global_ffi # => true

SweetMoon::State.new.meta.global_ffi # => true
```

**Caveats:**

Binding a C API globally it's irreversible, so if you start something with `global_ffi: true` and then change to `global_ffi: false`, it won't make the global one go away. If you need _local_, ensure that you do it from the first line and never put anything as global throughout the entire program life cycle.

Also, the simple action of accessing `meta.global_ff` will bind the API, so you need to set your desired configuration before checking.